### PR TITLE
Allow copying without the character limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Taburdle #
 
-Your Firefox tabs copied to your clipboard in an easily shareable form. Limited to 280 characters, useful for tweeting.
+Your Firefox tabs copied to your clipboard in an easily shareable form. Limited to 280 characters, useful for tweeting. Hold <kbd>Shift</kbd> to copy without the 280-character limit.
 
 ## documentation ##
 

--- a/background.js
+++ b/background.js
@@ -14,10 +14,11 @@ const FOOTER_CHARACTER_BUDGET = 6;
 // characters wide, so we want half of the TAB_CHARS, minus another
 const TAB_CHARS = Math.floor((MAX_CHARS - HEADER.length - FOOTER_CHARACTER_BUDGET) / 2) - 1;
 
-browser.browserAction.onClicked.addListener(async () => {
+browser.browserAction.onClicked.addListener(async (_tab, onClickData) => {
   let tabs = await browser.tabs.query({ currentWindow: true });
+  let charLimit = onClickData.modifiers.includes("Shift") ? tabs.length + 1 : TAB_CHARS;
   let tabStates = [];
-  for (let i = 0; i < tabs.length && tabStates.length < TAB_CHARS; ++i) {
+  for (let i = 0; i < tabs.length && tabStates.length < charLimit; ++i) {
     if (i > 0 && i % 5 == 0) {
       tabStates.push("\n");
     }
@@ -26,7 +27,7 @@ browser.browserAction.onClicked.addListener(async () => {
     tabStates.push(tab.pinned ? `🟪` : tab.discarded ? `🟨` : `🟩`);
   }
 
-  if (tabStates.length == TAB_CHARS) {
+  if (tabStates.length == charLimit) {
     tabStates.push("…");
   }
 


### PR DESCRIPTION
The 280-character limit does not do justice to the number of tabs I have, and Mozilla.social has a higher limit anyway, so with this change, you can hold <kbd>Shift</kbd> to remove the limit.